### PR TITLE
Fixed Carousel Book Image Size Issues on Mobile

### DIFF
--- a/src/components/books_carousel/books_carousel.component.jsx
+++ b/src/components/books_carousel/books_carousel.component.jsx
@@ -1,6 +1,6 @@
 import Carousel from "react-bootstrap/Carousel";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useLayoutEffect } from "react";
 import { Link } from "react-router-dom";
 
 import "./books_carousel.styles.css";
@@ -31,7 +31,22 @@ function createNestedBooksArray(books, pageSize) {
   return booksByPage;
 }
 
+function useWindowSize() {
+  const [size, setSize] = useState([0, 0]);
+  useLayoutEffect(() => {
+    function updateSize() {
+      setSize([window.innerWidth, window.innerHeight]);
+    }
+    window.addEventListener('resize', updateSize);
+    updateSize();
+    return () => window.removeEventListener('resize', updateSize);
+  }, []);
+  return size;
+}
+
+
 function BooksCarousel(props) {
+  const [window_width, window_height] = useWindowSize();
   const [index, setIndex] = useState(0);
   const [pageSize, setPageSize] = useState(5);
   const [booksByPage, setBooksByPage] = useState([]);
@@ -41,9 +56,18 @@ function BooksCarousel(props) {
   };
 
   useEffect(() => {
+    if (window_width < 768) {
+      setPageSize(1);
+    } else {
+      setPageSize(5);
+    }
+    console.log(pageSize)
+  }, [window_width]);
+
+  useEffect(() => {
     const booksArray = createNestedBooksArray(props.books, pageSize);
     setBooksByPage(booksArray);
-  }, [props.books]);
+  }, [props.books, pageSize]);
  
   return (
     <Carousel
@@ -56,21 +80,19 @@ function BooksCarousel(props) {
       {booksByPage.map((booksPerPage) => {
         return (
           <Carousel.Item>
-            <div className="carousel-images-container">
+            <div className="book-carousel-images-container">
               {booksPerPage.map((book) => {
                 if (book.isDummy)
                   return (<img
-                      className="carousel-cover-image"
+                      className="book-carousel-cover-image"
                       width="100"
                       height="180"
                       src="https://upload.wikimedia.org/wikipedia/commons/8/89/HD_transparent_picture.png"
                     />);
                 return (<Link to={`/books/info/${book.book_id}`} key={book.book_id}>
                   <img
-                    className="carousel-cover-image"
+                    className="book-carousel-cover-image"
                     src={book.cover_image}
-                    width="100"
-                    height="180"
                   />
                 </Link>);
               })}

--- a/src/components/books_carousel/books_carousel.styles.css
+++ b/src/components/books_carousel/books_carousel.styles.css
@@ -1,10 +1,17 @@
-.carousel-images-container {
+.book-carousel-images-container {
     text-align: center;
 }
 
-.carousel-cover-image {
+.book-carousel-cover-image {
   width: 10vw;
   height: auto;
   display: inline-block;
   margin: 2%;
+}
+
+@media screen and (max-width: 768px) {
+  .book-carousel-cover-image {
+    width: 47vw;
+    margin-bottom: 10px;
+  }
 }

--- a/src/components/grey_bubble/grey.bubble.styles.css
+++ b/src/components/grey_bubble/grey.bubble.styles.css
@@ -102,6 +102,10 @@
     align-items: center;
     margin-left: 0;
   }
+
+  .book-title {
+    font-size: large;
+  }
 }
 
 @media screen and (max-height: 680px) {

--- a/src/components/navbar/navbar.component.jsx
+++ b/src/components/navbar/navbar.component.jsx
@@ -11,6 +11,18 @@ import { LinkContainer } from "react-router-bootstrap";
 import { useState } from "react";
 import { Dropdown } from "react-bootstrap";
 
+
+// Redirect to random book
+function redirectToRandomBook() {
+  IonicPenAPI.getRandomBook()
+    .then((response) => {
+      window.location.href = "/books/info/" + response.book_id;
+    })
+    .catch((error) => {
+      console.log(error);
+    });
+}
+
 function NavBar(props) {
   const [query, setQuery] = useState("");
   const [showProfile, setShowProfile] = useState(false);
@@ -72,6 +84,7 @@ function NavBar(props) {
             <Button
               variant="success"
               size="sm"
+              onClick={() => redirectToRandomBook()}
             >
               Pick&nbsp;For&nbsp;Me
             </Button>
@@ -86,7 +99,7 @@ function NavBar(props) {
                 setShowProfile(false);
               }}
             >
-              <Button variant="outline-*" size="sm" href="/profile">
+              <Button variant="outline-*" size="sm" href="/profile" >
                 <Image
                   src="https://ionic-pen-public-assets.s3.amazonaws.com/profile.jpeg"
                   width="40"

--- a/src/pages/home_page/home_page.styles.css
+++ b/src/pages/home_page/home_page.styles.css
@@ -10,9 +10,9 @@
 }
 
 /* Media query to center text in mobile view */
-@media screen and (max-width: 730px) {
+@media screen and (max-width: 768px) {
     .carousel-text {
-        margin-right: 10%;
+        margin-right: 18%;
         text-align: center;
     }
 }


### PR DESCRIPTION
Changes:
Home page carousel now reduces page size to 1 on mobile view. Previously the books on the carousel were too small on mobile. 
Added media query on the corresponding CSS file to increase book image size on mobile view since now we are only displaying one book at a time.

"Choose for me" feature reinstated (previously removed while debugging).